### PR TITLE
Rootless and distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,125 @@
-# No specific reason for this image. Should probably change it at some point
-# Same CVEs as debian because they don't do patches
+# ╔═════════════════════════════════════════════════════╗
+# ║                       SETUP                         ║
+# ╚═════════════════════════════════════════════════════╝
+  # GLOBAL
+  ARG APP_UID=1000 \
+      APP_GID=1000
 
-FROM bitnami/minideb:bookworm
-ARG APP_UID=1000 \
-    APP_GID=1000
+  # FOREIGN IMAGES
+  FROM 11notes/distroless AS distroless
+#  FROM 11notes/distroless:dnslookup AS distroless-dnslookup
+  FROM 11notes/util:bin AS util-bin
 
-USER root
+# ╔═════════════════════════════════════════════════════╗
+# ║                       BUILD                         ║
+# ╚═════════════════════════════════════════════════════╝
 
-# Copied from https://ooni.org/install/cli/ubuntu-debian/ 
+  FROM golang:1.23.7-alpine AS build
+  COPY --from=util-bin / /
+  ARG APP_VERSION=3.26 \
+      BUILD_ROOT \
+      BUILD_BIN \
+      TARGETARCH=amd64 \
+      TARGETPLATFORM \
+      TARGETVARIANT \
+      BUILD_DIR=/go/probe-cli \
+      CGO_ENABLED=0
 
-RUN set -ex; \
-    apt update && apt install -y ca-certificates curl \
-    && install -m 0755 -d /etc/apt/keyrings \
-    && curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xb5a08f01796e7f521861b449372d1ff271f2dd50" -o /etc/apt/keyrings/ooni-apt-keyring.asc \
-    && chmod a+r /etc/apt/keyrings/ooni-apt-keyring.asc \
-    && echo "deb [signed-by=/etc/apt/keyrings/ooni-apt-keyring.asc] https://deb.ooni.org/ unstable main" | tee /etc/apt/sources.list.d/ooniprobe.list \
-    && apt update \
-    && apt install -y ooniprobe-cli \
-    && apt clean \
-    && rm -rf /var/lib/apt/lists/*
+  ENV BUILD_BIN=${BUILD_DIR}/probe-cli/CLI/ooniprobe-linux-${TARGETARCH}
 
-# Something about openshift not liking fixed UIDs, idk
-USER ${APP_UID}:${APP_GID}
-ENTRYPOINT [ "/usr/bin/ooniprobe", "run", "unattended" ]
+
+  RUN set -ex; \
+    apk --update --no-cache add \
+      curl \
+      wget \
+      unzip \
+      build-base \
+      linux-headers \
+      make \
+      cmake \
+      g++ \
+      git \
+      npm \
+      gpg \
+      zip \
+      tar \
+      yarn;
+
+  RUN set -ex; \
+    mkdir ${BUILD_DIR}; \
+    cd ${BUILD_DIR}; \
+    git clone https://github.com/ooni/probe-cli.git -b release/${APP_VERSION}; \
+    cd probe-cli; \
+    go run ./internal/cmd/buildtool linux static
+
+  RUN set -ex; \
+    eleven distroless ${BUILD_BIN};
+  # compress and copy. https://github.com/11notes/docker-util/blob/master/rootfs/usr/local/bin/.eleven/distroless
+
+# :: FILE SYSTEM
+  FROM alpine AS file-system
+  ARG APP_ROOT
+  USER root
+
+  RUN set -ex; \
+    mkdir -p /distroless${APP_ROOT}/etc; \
+    mkdir -p /distroless${APP_ROOT}/var; \
+    mkdir -p /distroless${APP_ROOT}/run; \
+    mkdir -p /distroless${APP_ROOT}/tmp; \
+    mkdir -p /distroless/.ooniprobe   
+# ooniprobe will exit it doesn't have tmp permissions, permissions set later
+
+  RUN set -ex; \
+    echo '{ \
+  "_version": 1, \
+  "_informed_consent": true, \
+  "sharing": { \
+    "upload_results": true \
+  }, \
+  "nettests": { \
+    "websites_max_runtime": 0 \
+  }, \
+  "advanced": {} \
+}' >> /distroless/.ooniprobe/config.json
+
+# This is an awful way to do this, should use ENV variables on the compose. 
+# The point is setting "_informed_consent" to "true" so it can start without editing a file.
+# Not editing a file is for running without bind mounts, and just named volumes.
+# At some point I might try do it from the compose, but for now, nope. 
+
+
+# ╔═════════════════════════════════════════════════════╗
+# ║                       IMAGE                         ║
+# ╚═════════════════════════════════════════════════════╝
+  # :: HEADER
+  FROM scratch
+
+  # :: default arguments
+    ARG TARGETPLATFORM \
+        TARGETOS \
+        TARGETARCH \
+        TARGETVARIANT \
+        APP_IMAGE \
+        APP_NAME \
+        APP_VERSION \
+        APP_ROOT \
+        APP_UID \
+        APP_GID \
+        APP_NO_CACHE
+
+  # :: default environment
+    ENV APP_IMAGE=${APP_IMAGE} \
+      APP_NAME=${APP_NAME} \
+      APP_VERSION=${APP_VERSION} \
+      APP_ROOT=${APP_ROOT}
+
+  # :: multi-stage
+    COPY --from=distroless / /
+#    COPY --from=distroless-dnslookup / /
+    COPY --from=build /distroless/ /
+    COPY --from=file-system --chown=${APP_UID}:${APP_GID} /distroless/ /
+
+
+# :: EXECUTE
+  USER ${APP_UID}:${APP_GID}
+ENTRYPOINT [ "/usr/local/bin/ooniprobe-linux-amd64", "run", "unattended" ]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-Not as awful as previously.
-
-First time it will loop. You need to edit ```config.json``` ```"_informed_consent": false,``` to ```"_informed_consent": true,```.
-You can adjust more settings in the same file: See [docs](https://ooni.org/support/ooni-probe-cli/#configuration-file)   
-
 Runs ```ooniprobe run unattended``` on its own
+  
+Rootless and distroless

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,17 +7,13 @@ services:
     environment:
       - TZ=Europe/Madrid
     restart: unless-stopped
-    volumes:
-      - "./data:/.ooniprobe" # You will need to edit config.json inside here
     dns:
       - 1.1.1.1
       - 1.0.0.1
-      - 2606:4700:4700::1111
-      - 2606:4700:4700::1001
     networks:
       - ooni-net
     mem_limit: 128m
 
 networks:
   ooni-net:
-    enable_ipv6: true  # Some blocks only affect ipv4 and not ipv6, so ooni benefits if your setup ipv6 properly
+    enable_ipv6: true


### PR DESCRIPTION
Comes with 
 `"_informed_consent": true` and `"upload_results": true` by default. 
 I'll move it to env variables sometime